### PR TITLE
Fix: Return only reporting errors in validateReportingStructure function

### DIFF
--- a/actions/validateReportingStructure.js
+++ b/actions/validateReportingStructure.js
@@ -1,4 +1,4 @@
-export const validateReportingStructure = (records) => {
+export const validateReportingStructure = (records, returnErrors = false) => {
   const reportingErrors = [] // Array to store records with reporting errors
   const employees = {} // Object to store employee records by Applicant_ID
   const visited = new Set() // Set to keep track of visited Applicant_IDs
@@ -108,5 +108,8 @@ export const validateReportingStructure = (records) => {
 
   console.log('Reporting Errors: ' + JSON.stringify(reportingErrors))
 
-  return reportingErrors
+  if (returnErrors) {
+    return reportingErrors
+  }
+  return records
 }

--- a/actions/validateReportingStructure.js
+++ b/actions/validateReportingStructure.js
@@ -108,5 +108,5 @@ export const validateReportingStructure = (records) => {
 
   console.log('Reporting Errors: ' + JSON.stringify(reportingErrors))
 
-  return records
+  return reportingErrors
 }


### PR DESCRIPTION
This commit addresses the issue identified by Jonathan with the supervisory org build. Instead of returning all records, the `validateReportingStructure` function now only returns reporting errors.